### PR TITLE
[MOD] Board / 게시글 수정, 게시글 조회 부분 코드 변경

### DIFF
--- a/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
+++ b/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
@@ -13,6 +13,8 @@ import capstone.capstone7.global.common.response.SliceResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +36,7 @@ public class BoardController {
     }
 
     @GetMapping()
-    public SliceResponseDto<GetBoardResponseDto> getBoardsList(Pageable pageable){
+    public SliceResponseDto<GetBoardResponseDto> getBoardsList(@PageableDefault(sort="modifiedDate",direction = Sort.Direction.DESC) Pageable pageable){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
         return new SliceResponseDto<>(boardService.getBoardsList(pageable));
     }
 

--- a/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardResponseDto.java
+++ b/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardResponseDto.java
@@ -1,27 +1,33 @@
 package capstone.capstone7.domain.board.dto.response;
 
 import capstone.capstone7.domain.board.entity.Board;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 public class GetBoardResponseDto {
-    private Long id;
+    private Long boardId;
     private String title;
     private String content;
     private String tag;
     private String image;
     private Boolean isSolved;
     private Long memberId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd' 'HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime modifiedDate;
 
     public GetBoardResponseDto(Board board) {
-        this.id = board.getId();
+        this.boardId = board.getId();
         this.title = board.getTitle();
         this.content = board.getContent();
         this.tag = board.getTag().toString();
         this.image = board.getImage();
         this.isSolved = board.getIsSolved();
         this.memberId = board.getMember().getId();
+        this.modifiedDate = board.getModifiedDate();
     }
 }

--- a/src/main/java/capstone/capstone7/domain/board/entity/Board.java
+++ b/src/main/java/capstone/capstone7/domain/board/entity/Board.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import static java.lang.Boolean.*;
+
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -41,12 +43,15 @@ public class Board extends BaseTimeEntity {
         this.tag = tag;
         this.image = image;
         this.likeNum = 0;
+        this.isSolved = FALSE;
         this.member = member;
     }
 
     public void boardContentUpdate(String boardImage, BoardUpdateRequestDto boardUpdateRequestDto){
         if(boardImage != null){
             this.image = boardImage;
+        }else{
+            this.image = null;
         }
 
         if(boardUpdateRequestDto.getTitle() != ""){

--- a/src/main/java/capstone/capstone7/domain/board/service/BoardService.java
+++ b/src/main/java/capstone/capstone7/domain/board/service/BoardService.java
@@ -61,7 +61,9 @@ public class BoardService {
     public BoardUpdateResponseDto updateBoard(Member member, Long boardId, MultipartFile boardImage, BoardUpdateRequestDto boardUpdateRequestDto){
 
         Board board = boardRepository.findById(boardId).orElseThrow(() -> new BusinessException(NOT_EXIST_BOARD));
-
+        if(board.getImage()!=null){
+            fileService.deleteFile(board.getImage());
+        }
         String savedFilePath = fileService.uploadFileToS3(boardImage, member.getId());
         board.boardContentUpdate(savedFilePath, boardUpdateRequestDto);
 


### PR DESCRIPTION
1. 게시글 조회
- @PageableDefault로 기본적으로 수정일자 기준 내림차순(최신순)정렬해서 보내지도록 설정
- 수정일자도 같이 받을 수 있도록 response DTO 수정

2. 게시글 수정
- 수정시 null값이 들어오면, 게시글 이미지 필드 null로 수정안되는 로직이라서 로직 수정
- 수정시 기존에 이미지 있었다면, S3에서 해당 이미지 지우는 코드 추가