### PR TITLE
[MOD/#19] Board / 게시글 목록 조회시 createdDate로 정렬, 추후 수정되더라도 순서는 유지되도록

### DIFF
--- a/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
+++ b/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
@@ -34,7 +34,13 @@ public class BoardController {
     }
 
     @GetMapping()
+<<<<<<< Updated upstream
     public SliceResponseDto<GetBoardListResponseDto> getBoardsList(@PageableDefault(sort="modifiedDate",direction = Sort.Direction.DESC) Pageable pageable, @RequestParam Tag tag){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
+=======
+    public SliceResponseDto<GetBoardResponseDto> getBoardsList(@PageableDefault(sort="createdDate",direction = Sort.Direction.DESC) Pageable pageable, @RequestParam Tag tag){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
+        log.info("tag {}", tag);
+
+>>>>>>> Stashed changes
         return new SliceResponseDto<>(boardService.getBoardsList(tag, pageable));
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         #        show_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod, security
+    active: local, security
   #mvc:
     #pathmatch:
       #matching-strategy: ant-path-matcher


### PR DESCRIPTION
## 개요
## 작업사항
## 변경로직
### 변경전
게시글 목록 조회시 PageableDefault에서 정렬 조건이 modifiedDate
### 변경후
게시글 목록 조회시 PageableDefault에서 정렬 조건이 createdDate