### PR TITLE
[FEAT/#19] Board / 게시글 조회시 생성일자 기준 정렬, 생성일자를 DTO에 반환

### DIFF
--- a/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
+++ b/src/main/java/capstone/capstone7/domain/board/controller/BoardController.java
@@ -34,13 +34,7 @@ public class BoardController {
     }
 
     @GetMapping()
-<<<<<<< Updated upstream
-    public SliceResponseDto<GetBoardListResponseDto> getBoardsList(@PageableDefault(sort="modifiedDate",direction = Sort.Direction.DESC) Pageable pageable, @RequestParam Tag tag){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
-=======
-    public SliceResponseDto<GetBoardResponseDto> getBoardsList(@PageableDefault(sort="createdDate",direction = Sort.Direction.DESC) Pageable pageable, @RequestParam Tag tag){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
-        log.info("tag {}", tag);
-
->>>>>>> Stashed changes
+    public SliceResponseDto<GetBoardListResponseDto> getBoardsList(@PageableDefault(sort="createdDate",direction = Sort.Direction.DESC) Pageable pageable, @RequestParam Tag tag){ // 기본적으로는 수정일자(modifiedDate) 기준 오름차순 정렬
         return new SliceResponseDto<>(boardService.getBoardsList(tag, pageable));
     }
 

--- a/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardListResponseDto.java
+++ b/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardListResponseDto.java
@@ -22,7 +22,7 @@ public class GetBoardListResponseDto {
     private Integer likeNum;
     private Integer commentNum;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd' 'HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime modifiedDate;
+    private LocalDateTime createdDate;
 
     public GetBoardListResponseDto(Board board, Member member, Integer commentNum) {
         this.boardId = board.getId();
@@ -32,7 +32,7 @@ public class GetBoardListResponseDto {
         this.image = board.getImage();
         this.isSolved = board.getIsSolved();
         this.memberId = board.getMember().getId();
-        this.modifiedDate = board.getModifiedDate();
+        this.createdDate = board.getCreatedDate();
         this.nickname = member.getNickname();
         this.likeNum = board.getLikeNum();
         this.commentNum = commentNum;

--- a/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardResponseDto.java
+++ b/src/main/java/capstone/capstone7/domain/board/dto/response/GetBoardResponseDto.java
@@ -23,7 +23,7 @@ public class GetBoardResponseDto {
     private Integer likeNum;
     private List<Long> likeMemberIds;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd' 'HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime modifiedDate;
+    private LocalDateTime createdDate;
 
     public GetBoardResponseDto(Board board, Member member, List<Long> likeMemberIds) {
         this.boardId = board.getId();
@@ -33,7 +33,7 @@ public class GetBoardResponseDto {
         this.image = board.getImage();
         this.isSolved = board.getIsSolved();
         this.memberId = board.getMember().getId();
-        this.modifiedDate = board.getModifiedDate();
+        this.createdDate = board.getCreatedDate();
         this.nickname = member.getNickname();
         this.likeNum = board.getLikeNum();
         this.likeMemberIds = likeMemberIds;


### PR DESCRIPTION
## 변경로직
### 변경전
게시글 조회시 수정일자 기준 정렬, 수정일자를 DTO에 반환
### 변경후
게시글 조회시 생성일자 기준 정렬, 생성일자를 DTO에 반환