### PR TITLE
[FEAT] Docker를 사용한 배포

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,28 +59,23 @@ jobs:
       with:
         arguments: clean build -x test
 
-    # (4) AWS 인증 (IAM 사용자 Access Key, Secret Key 활용)
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+    # spring 이미지 빌드 및 도커허브에 push
+    - name: spring docker build and push
+      run : |
+        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        docker build -t ${{ secrets.DOCKER_REPO }} .
+        docker push ${{ secrets.DOCKER_REPO }}
+
+    # 서버에 접속하여 도커 이미지를 pull 받고 실행하기
+    - name: Deploy to prod
+      uses: appleboy/ssh-action@master
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
-
-    # (5) 빌드 결과물을 S3 버킷에 업로드
-    - name: Upload to AWS S3
-      run: |
-        aws deploy push \
-          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-          --ignore-hidden-files \
-          --s3-location s3://$S3_BUCKET_NAME/$GITHUB_SHA.zip \
-          --source .
-
-    # (6) S3 버킷에 있는 파일을 대상으로 CodeDeploy 실행
-    - name: Deploy to AWS EC2 from S3
-      run: |
-        aws deploy create-deployment \
-          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
-          --s3-location bucket=$S3_BUCKET_NAME,key=$GITHUB_SHA.zip,bundleType=zip
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        key: ${{ secrets.KEY }}
+        port: 22
+        script: |
+          docker rm -f $(docker ps -qa)
+          docker pull ${{ secrets.DOCKER_REPO }}
+          docker-compose up -d
+          docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile
+# Docker 이미지가 어떤 단계를 거쳐 Build되는지 담고 있는 텍스트 파일
+
+# 1. FROM
+# base이미지 지정, 보통 Docker Hub와 같이 Docker repository에 올려 놓은 잘 알려진 공개 이미지인 경우가 많다.
+# ex) ubuntu:lastest, openjdk:17-jdk-alpine
+
+# 2. WORKDIR
+# 쉘의 cd 명령어처럼, 컨테이너상에서 작업 디렉토리 전환을 위해서 사용
+# RUN, CMD, ENTRYPOINT, COPY, ADD 명령문은 해당 디렉토리를 기준으로 실행
+
+# ENTRYPOINT
+# 이미지를 컨테이너로 띄울 때 항상 실행되어야하는 커멘트를 지정할 때 유용
+# Docker 이미지를 마치 하나의 실행 파일처럼 사용할 때 유용
+# /- WHY? :  컨테이너가 뜰 때, ENTRYPOINT 명령문으로 지정된 커멘드 실행되고, 커멘드로 실행된 프로세스가 죽을 때, 컨테이너도 따라서 종료
+
+FROM openjdk:17-jdk-alpine
+COPY build/libs/*jar capstone7.jar
+ENTRYPOINT ["java","-jar","/capstone7.jar"]
+# 설정파일 분리해서 사용시
+# java -jar -Dspring.profiles.active=prod capstone7.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+
+  spring:
+    container_name: spring
+    image: mingsound/sejong-capstone
+    expose:
+      - 8080
+    ports:
+      - 8080:8080


### PR DESCRIPTION
## 개요

## 작업사항
## 변경로직
### 변경전
기존에는 github actions에서 jar파일을 생성한 뒤, S3로 zip파일 형태로 옮기고, EC2의 Code Deploy가 S3에서 해당 zip파일로부터 jar파일을 복사해 실행하였다.
### 변경후
github actions에서 빌드하여 jar파일 생성 후, Dockerfile을 기반으로 도커 이미지를 build하고 도커 허브에 push한다.
이후 서버에 접속해 도커 이미지를 pull 받고 실행한다.