### PR TITLE
[BUG] Board / 게시글 삭제시 연관된 엔티티들 먼저 삭제

### DIFF
--- a/src/main/java/capstone/capstone7/domain/board/service/BoardService.java
+++ b/src/main/java/capstone/capstone7/domain/board/service/BoardService.java
@@ -87,6 +87,9 @@ public class BoardService {
         if (board.getImage() != null){
             fileService.deleteFile(board.getImage());
         }
+
+        likeRepository.deleteAllInBatch(likeRepository.findAllLikeByBoard(board));
+        commentRepository.deleteAllInBatch(commentRepository.findAllCommentByBoard(board));
         boardRepository.deleteById(boardId); // 해당 boardId를 가진 Board가 없다면, delete 요청 무시
         return new BoardDeleteResponseDto(boardId);
     }

--- a/src/main/java/capstone/capstone7/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/capstone/capstone7/domain/comment/repository/CommentRepository.java
@@ -17,4 +17,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<CommentGetResponseDto> findAllComment(@Param("boardId") Long boardId, Pageable pageable);
 
     Integer countByBoard(Board board);
+
+    List<Comment> findAllCommentByBoard(Board board);
 }

--- a/src/main/java/capstone/capstone7/domain/like/repository/LikeRepository.java
+++ b/src/main/java/capstone/capstone7/domain/like/repository/LikeRepository.java
@@ -16,4 +16,6 @@ public interface LikeRepository extends JpaRepository<BoardLike, Long> {
 
     @Query("select l.member.id from BoardLike l where l.board = :board")
     List<Long> findLikeMemberIdsByBoard(@Param("board") Board board);
+
+    List<BoardLike> findAllLikeByBoard(Board board);
 }


### PR DESCRIPTION
## 개요
게시글을 삭제할 때 boardId를 fk로 가지고 있는 댓글과 좋아요 엔티티들을 모두 삭제한다.

## 작업사항
delete쿼리가 엔티티당 1개씩 실행되는 deleteAll 대신 여러개의 엔티티 List를 인자로 받아서 1개의 delete 쿼리를 수행하는 deleteAllInBatch를 사용하였다.

## 변경로직
### 변경전
```java
        boardRepository.deleteById(boardId); // 해당 boardId를 가진 Board가 없다면, delete 요청 무시
```
### 변경후
```java
        likeRepository.deleteAllInBatch(likeRepository.findAllLikeByBoard(board));
        commentRepository.deleteAllInBatch(commentRepository.findAllCommentByBoard(board));
        boardRepository.deleteById(boardId); // 해당 boardId를 가진 Board가 없다면, delete 요청 무시
```