### PR TITLE
[FIX] Member / 회원 탈퇴시 fk로 연관된 엔티티들 먼저 삭제

### DIFF
--- a/src/main/java/capstone/capstone7/domain/board/repository/BoardRepository.java
+++ b/src/main/java/capstone/capstone7/domain/board/repository/BoardRepository.java
@@ -2,15 +2,18 @@ package capstone.capstone7.domain.board.repository;
 
 import capstone.capstone7.domain.board.entity.Board;
 import capstone.capstone7.domain.board.entity.enums.Tag;
+import capstone.capstone7.domain.member.entity.Member;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("select b from Board b join fetch b.member where b.tag = :tag")
     Slice<Board> findBoardListBy(@Param("tag") Tag tag, Pageable pageable);
 
-
+    List<Board> findAllBoardByMember(Member member);
 }

--- a/src/main/java/capstone/capstone7/domain/member/service/MemberService.java
+++ b/src/main/java/capstone/capstone7/domain/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package capstone.capstone7.domain.member.service;
 
+import capstone.capstone7.domain.board.entity.Board;
+import capstone.capstone7.domain.board.repository.BoardRepository;
+import capstone.capstone7.domain.board.service.BoardService;
 import capstone.capstone7.domain.member.dto.request.MemberPatchRequestDto;
 import capstone.capstone7.domain.member.dto.response.MemberDeleteResponseDto;
 import capstone.capstone7.domain.member.dto.response.MemberGetResponseDto;
@@ -12,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static capstone.capstone7.global.error.enums.ErrorMessage.INVALID_USER;
 import static capstone.capstone7.global.error.enums.ErrorMessage.NOT_EXIST_USER;
 
@@ -20,6 +25,8 @@ import static capstone.capstone7.global.error.enums.ErrorMessage.NOT_EXIST_USER;
 @Service
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final BoardService boardService;
+    private final BoardRepository boardRepository;
 
     public MemberGetResponseDto getMemberInfo(Long memberId, LoginUser loginUser){
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new BusinessException(NOT_EXIST_USER));
@@ -52,6 +59,13 @@ public class MemberService {
             throw new BusinessException(INVALID_USER);
         }
 
+        // 회원이 작성한 모든 게시물 삭제 및, 해당 게시물과 연관된 댓글, 좋아요 삭제
+        List<Board> allBoardByMember = boardRepository.findAllBoardByMember(member);
+        for (Board board : allBoardByMember) {
+            boardService.deleteBoard(board.getId());
+        }
+
+        // 회원 삭제
         memberRepository.deleteById(memberId);
 
         return new MemberDeleteResponseDto(member.getId());


### PR DESCRIPTION
## 개요
회원 탈퇴시 fk로 연관된 게시물, 그리고 게시물과 연관된 댓글, 좋아요를 먼저 삭제해야한다.

## 작업사항
boardService에 작성해둔 deleteBoard를 사용하였다.

## 변경로직
### 변경전
```java
        // 회원 삭제
        memberRepository.deleteById(memberId);
```
### 변경후
```java
        // 회원이 작성한 모든 게시물 삭제 및, 해당 게시물과 연관된 댓글, 좋아요 삭제
        List<Board> allBoardByMember = boardRepository.findAllBoardByMember(member);
        for (Board board : allBoardByMember) {
            boardService.deleteBoard(board.getId());
        }

        // 회원 삭제
        memberRepository.deleteById(memberId);
```